### PR TITLE
Add keybinds

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -1,11 +1,13 @@
+import { Actions, on } from "./keybinds.js";
+
 let ws = null;
 let infoTable = null;
 let player = null;
 let watching = false;
 let joining = false;
 let watchers = [];
-
 let [userplay, userpause, userseek] = [true, true, true];
+
 let onplayimpl = e => {
 	if (userplay == false) {
 		userplay = true;
@@ -30,12 +32,12 @@ let onseekimpl = e => {
 		onuserseek(e);
 	}
 };
-let onuserplay = () => {};
-let onuserpause = () => {};
-let onuserseek = () => {};
-let onplay = () => {};
-let onpause = () => {};
-let onseek = () => {};
+let onuserplay = () => { };
+let onuserpause = () => { };
+let onuserseek = () => { };
+let onplay = () => { };
+let onpause = () => { };
+let onseek = () => { };
 
 function play() {
 	if (player != null) {
@@ -46,6 +48,7 @@ function play() {
 		player.play();
 	}
 }
+
 function pause() {
 	if (player != null) {
 		if (player.paused) {
@@ -55,6 +58,7 @@ function pause() {
 		player.pause();
 	}
 }
+
 function seek(pos) {
 	if (player != null) {
 		userseek = false;
@@ -141,8 +145,8 @@ function loadJoinPage(roomName) {
 		joining = true;
 
 		ws = new WebSocket(`ws://localhost:8003/api/${roomName}/${name.value}/`);
-		ws.onerror = (e) => {console.error(e);}
-		ws.onopen = () => {console.log("hello");}
+		ws.onerror = (e) => { console.error(e); }
+		ws.onopen = () => { console.log("hello"); }
 		ws.onmessage = onWebSocketMessage;
 	}
 	join.onclick = connect;
@@ -174,15 +178,15 @@ function loadVideoPage(meta) {
 	player.onseeked = onseekimpl;
 	onuserplay = e => {
 		console.log("Sending play at :" + player.currentTime);
-		ws.send(JSON.stringify({ play: { requestId: 0, time: player.currentTime }}));
+		ws.send(JSON.stringify({ play: { requestId: 0, time: player.currentTime } }));
 	}
 	onuserpause = e => {
 		console.log("Sending pause at :" + player.currentTime);
-		ws.send(JSON.stringify({ pause: { requestId: 0, time: player.currentTime }}));
+		ws.send(JSON.stringify({ pause: { requestId: 0, time: player.currentTime } }));
 	}
 	onuserseek = e => {
 		console.log("Sending seek at :" + player.currentTime);
-		ws.send(JSON.stringify({ seek: { requestId: 0, time: player.currentTime }}));
+		ws.send(JSON.stringify({ seek: { requestId: 0, time: player.currentTime } }));
 	}
 
 	// TODO: check room state
@@ -268,5 +272,10 @@ function bufferedFromPosition(video, pos) {
 
 	return 0;
 }
+
+// Register keybinds
+on(Actions.PAUSE, () => {
+	// Whatever happens when users want to pause
+})
 
 /* vi: set sw=4 ts=4: */

--- a/site/app.js
+++ b/site/app.js
@@ -1,4 +1,4 @@
-import { Actions, on } from "./keybinds.js";
+import { Action, on } from "./keybinds.js";
 
 let ws = null;
 let infoTable = null;
@@ -274,7 +274,7 @@ function bufferedFromPosition(video, pos) {
 }
 
 // Register keybinds
-on(Actions.PAUSE, () => {
+on(Action.PAUSE, () => {
 	// Whatever happens when users want to pause
 })
 

--- a/site/index.html
+++ b/site/index.html
@@ -32,11 +32,11 @@
 
 <template id="infoRow">
 	<tr>
-	<td id="name">
-	<td id="position">
-	<td id="status">
+		<td id="name">
+		<td id="position">
+		<td id="status">
 </template>
 
-<script src="/app.js"></script>
+<script src="./app.js"></script>
 
 <!-- vi: set sw=4 ts=4: -->

--- a/site/index.html
+++ b/site/index.html
@@ -37,6 +37,6 @@
 		<td id="status">
 </template>
 
-<script src="./app.js"></script>
+<script src="./app.js" type="module"></script>
 
 <!-- vi: set sw=4 ts=4: -->

--- a/site/keybinds.js
+++ b/site/keybinds.js
@@ -1,0 +1,89 @@
+// Default keybinds
+const Actions = {
+  VOLUME_UP: '+',
+  VOLUME_DOWN: '-',
+  PAUSE: 'Space',
+  GAMMA_UP: "0",
+  GAMMA_DOWN: "9",
+}
+
+/**
+ * 
+ * @param {keyof Actions} key Existing KeyAction
+ * @param {string} newKeybind Keybind to replace the current one
+ */
+function rebind(key, newKeybind) {
+  if (!Actions[key])
+    throw new TypeError('This keybind does not exist')
+
+  Actions[key] = newKeybind
+}
+
+// Store callbacks per key combination
+const callbackRegistry = new Map()
+
+/**
+ * Bind callback to a key or set of keys
+ * 
+ * @param {string | string[]} key string or array of strings
+ * @param {() => void} callback Executes when the key(s) are pressed in succession
+ * @returns Function which removes check
+ */
+function on(key, callback) {
+  if (callbackRegistry.has(key)) {
+    // Update
+    const current = callbackRegistry.get(key)
+    current.push(callback)
+    callbackRegistry.set(key, current)
+  } else {
+    // Create new entry for key
+    callbackRegistry.set(key, [callback])
+  }
+  return () => {
+    const current = callbackRegistry.get(key)
+    const updated = current.filter((c) => c !== callback)
+    callbackRegistry.set(key, updated)
+  }
+}
+
+// Store the last n amount of keys pressed
+const keyPressRegistry = []
+
+function areKeysPressed(keys) {
+  return keys.every(
+    (key, index) => keyPressRegistry.at(index - keys.length) === key,
+  )
+}
+
+/**
+ * Internally handles the keypresses
+ * 
+ * @param {KeyboardEvent} event 
+ */
+function keyPressHandler(evt) {
+  const key = evt.key.trim().length > 0 ? evt.key : evt.code
+  console.log(key)
+
+  keyPressRegistry.push(key)
+
+  if (keyPressRegistry.length > 10)
+    keyPressRegistry.shift()
+
+  for (const keyCombination of callbackRegistry.keys()) {
+    // Turn mere strings to arrays as well
+    const keys = Array.isArray(keyCombination) ? keyCombination : [keyCombination]
+
+    if (areKeysPressed(keys)) {
+      for (const cb of callbackRegistry.get(keyCombination))
+        cb()
+    }
+  }
+}
+
+document.addEventListener('keydown', keyPressHandler)
+
+export {
+  rebind,
+  on,
+  Actions
+}

--- a/site/keybinds.js
+++ b/site/keybinds.js
@@ -1,5 +1,5 @@
 // Default keybinds
-const Actions = {
+const Action = {
   VOLUME_UP: '+',
   VOLUME_DOWN: '-',
   PAUSE: 'Space',
@@ -9,14 +9,14 @@ const Actions = {
 
 /**
  * 
- * @param {keyof Actions} key Existing KeyAction
+ * @param {keyof Action} key Existing KeyAction
  * @param {string} newKeybind Keybind to replace the current one
  */
 function rebind(key, newKeybind) {
-  if (!Actions[key])
+  if (!Action[key])
     throw new TypeError('This keybind does not exist')
 
-  Actions[key] = newKeybind
+  Action[key] = newKeybind
 }
 
 // Store callbacks per key combination
@@ -85,5 +85,5 @@ document.addEventListener('keydown', keyPressHandler)
 export {
   rebind,
   on,
-  Actions
+  Action
 }


### PR DESCRIPTION
This PR adds option for developers to easily listen for keyboard events. This also includes multiple keys set in succession. This functionality is implemented through `Actions` object, which contains the default keybinds.

This way, even if users change their keybinds, we don't need to register new event listeners, based on their key. Using the `Actions` object gives us an `ID` for an action, which doesn't change at all.

```ts
on(Actions.PAUSE, () => { ... });
```

But, if desired, we can also listen to specific succession of key presses.

```ts
on(['Ctrl', 's'], () => { ... })
```
---

Users can then (through UI hopefully) update their keybinds if desired,

```ts
rebind(Actions.PAUSE, 'new_pause_key')
```


